### PR TITLE
Accept java-1.X syntax in update-alternatives, abort if not found

### DIFF
--- a/implementations/config.inc
+++ b/implementations/config.inc
@@ -17,9 +17,11 @@ then
   export JAVA9_HOME=`/usr/libexec/java_home -v 9`
 elif [ -x /usr/sbin/update-java-alternatives ]
 then
-  jvm_info=(`/usr/sbin/update-java-alternatives -l | grep java-8`)
+  jvm_info=(`/usr/sbin/update-java-alternatives -l | grep 'java-8\|java-1.8' || true`)
+  if [[ -z $jvm_info ]]; then echo "Java 8 installation not found"; exit 1; fi
   export JAVA8_HOME=${jvm_info[2]}
-  jvm_info=(`/usr/sbin/update-java-alternatives -l | grep java-9`)
+  jvm_info=(`/usr/sbin/update-java-alternatives -l | grep 'java-9\|java-1.9' || true`)
+  if [[ -z $jvm_info ]]; then echo "Java 9 installation not found"; exit 1; fi
   export JAVA9_HOME=${jvm_info[2]}
 else
   echo "Java directories could not be guessed, please check config.inc"


### PR DESCRIPTION
- On my system, update-alternatives lists java installations as `java-1.8.0-XXX` etc
- Please consider using java 11 instead of 9 everywhere since 9 was this weird short-term release and is no longer supported and available on Ubuntu repositories. Both 11 and 13 are available and work fine with the benchmarks